### PR TITLE
Fix admin redirect issue by adding a loading state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,15 @@ import Navbar from "./Components/Navbar";
 import ProtectedRoute from "./Components/ProtectedRoute";
 
 function AppContent() {
-  const { user, isAdmin } = useAuth();
+  const { user, isAdmin, isAdminLoading } = useAuth();
+
+  if (isAdminLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
 
   if (isAdmin) {
     return (

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -14,6 +14,7 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isAdminLoading, setIsAdminLoading] = useState(true);
 
   // Track login attempts (rate limiting)
   const loginAttempts = useRef(0);
@@ -43,8 +44,10 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       setUser(firebaseUser || null);
+      setLoading(false); // Auth state is known now
 
       if (firebaseUser) {
+        setIsAdminLoading(true);
         try {
           // Check Firestore for admin role
           const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
@@ -61,12 +64,13 @@ export const AuthProvider = ({ children }) => {
         } catch (error) {
           console.error("Error checking admin status:", error);
           setIsAdmin(false);
+        } finally {
+          setIsAdminLoading(false);
         }
       } else {
         setIsAdmin(false);
+        setIsAdminLoading(false);
       }
-
-      setLoading(false);
     });
 
     return () => unsubscribe();
@@ -109,7 +113,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout, isAdmin, loginAsAdmin }}>
+    <AuthContext.Provider value={{ user, loading, logout, isAdmin, loginAsAdmin, isAdminLoading }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
This commit fixes a bug where an admin user would be briefly redirected to the user page before being sent to the admin dashboard.

This was caused by a race condition where the UI would render before the user's admin status was fully confirmed.

The fix introduces a new `isAdminLoading` state to the `AuthContext`. The main application component now uses this state to display a loading indicator until the admin check is complete, preventing the premature redirect.